### PR TITLE
Add mock temperature script and daily GitHub Actions workflow

### DIFF
--- a/.github/workflows/temperature.yml
+++ b/.github/workflows/temperature.yml
@@ -1,0 +1,18 @@
+name: Temperature Check
+
+on:
+  # 毎日 09:00 JST（00:00 UTC）に定期実行する．
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run mock temperature check
+        run: python temperature.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+
+## Mock 体温チェック
+
+- `temperature.py` は，mock の体温を 35.8〜40.0℃ の乱数で生成するスクリプトです．
+- `.github/workflows/temperature.yml` は，毎日 09:00 JST（00:00 UTC）に `temperature.py` を定期実行します．
+- 必要に応じて，GitHub Actions の `workflow_dispatch` から手動実行もできます．

--- a/temperature.py
+++ b/temperature.py
@@ -1,0 +1,19 @@
+import random
+from datetime import datetime, timezone
+
+
+def measure_temperature_mock(seed: int | None = None) -> float:
+    """Mock の体温を生成する．"""
+    random.seed(seed)
+    return round(random.uniform(35.8, 40.0), 1)
+
+
+def main() -> None:
+    # 実行時刻を残しておくと，定期実行時のトレースがしやすい．
+    measured_at = datetime.now(timezone.utc).isoformat()
+    temperature = measure_temperature_mock()
+    print(f"[{measured_at}] Mock temperature: {temperature}℃")
+
+
+if __name__ == "__main__":
+    main()

--- a/temperature.py
+++ b/temperature.py
@@ -4,8 +4,8 @@ from datetime import datetime, timezone
 
 def measure_temperature_mock(seed: int | None = None) -> float:
     """Mock の体温を生成する．"""
-    random.seed(seed)
-    return round(random.uniform(35.8, 40.0), 1)
+    rng = random.Random(seed)
+    return round(rng.uniform(35.8, 40.0), 1)
 
 
 def main() -> None:


### PR DESCRIPTION
### Motivation

- Provide a simple mock body-temperature generator for periodic execution and traceability. 
- Ensure scheduled runs are recorded with timestamps to aid debugging of automation runs.

### Description

- Add `temperature.py` which exposes `measure_temperature_mock(seed: int | None = None) -> float` and a `main()` that prints a UTC ISO timestamp and a mock temperature in the range 35.8–40.0℃ rounded to 0.1. 
- Add a GitHub Actions workflow at `.github/workflows/temperature.yml` that runs `python temperature.py` daily at 09:00 JST (cron `"0 0 * * *"`) and supports manual `workflow_dispatch`, using Python 3.11. 
- Add `README.md` documenting the mock script and the workflow schedule and manual trigger option. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdd9ca050832787441fcb8ec44224)